### PR TITLE
Update activerecord version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,44 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.0.0.1)
-      activesupport (= 5.0.0.1)
-    activerecord (5.0.0.1)
-      activemodel (= 5.0.0.1)
-      activesupport (= 5.0.0.1)
-      arel (~> 7.0)
-    activesupport (5.0.0.1)
+    activemodel (5.1.4)
+      activesupport (= 5.1.4)
+    activerecord (5.1.4)
+      activemodel (= 5.1.4)
+      activesupport (= 5.1.4)
+      arel (~> 8.0)
+    activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (7.1.2)
+    arel (8.0.0)
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     faker (1.6.6)
       i18n (~> 0.5)
-    i18n (0.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.9.3)
+      concurrent-ruby (~> 1.0)
     method_source (0.8.2)
-    minitest (5.9.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    minitest (5.11.3)
+    netrc (0.11.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (11.2.2)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -41,9 +54,12 @@ GEM
     rspec-support (3.5.0)
     slop (3.6.0)
     sqlite3 (1.3.11)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
 
 PLATFORMS
   ruby
@@ -53,8 +69,9 @@ DEPENDENCIES
   faker
   pry
   rake
+  rest-client
   rspec
   sqlite3
 
 BUNDLED WITH
-   1.12.5
+   1.16.1


### PR DESCRIPTION
Update active record from version `5.0.0.1` to `5.1.4`

This is related to Active Record Basics lecture, in which we're inheriting from `ActiveRecord::Migration[5.1]` in slides, cf https://karr.lewagon.com/lectures/db/03-active-record#/3/3

Also, still in the lecture, the slide https://karr.lewagon.com/lectures/db/03-active-record#/2 should be updated to get active record in version `5.1.x` (To be coherent with the inherited class for migations)