### PR TITLE
Bump faker and rake

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,11 +19,11 @@ GEM
     diff-lcs (1.2.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    faker (1.6.6)
-      i18n (~> 0.5)
+    faker (1.9.1)
+      i18n (>= 0.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.9.3)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
     method_source (0.8.2)
@@ -41,7 +41,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rainbow (3.0.0)
-    rake (11.2.2)
+    rake (12.3.1)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -92,4 +92,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.17.1


### PR DESCRIPTION
Bump `faker` to 1.9.1 so that we can play with everything [listed here](https://github.com/stympy/faker/#contents). Also bump `rake` to remove deprecation warnings.