### PR TITLE
 Change :migrate task __FILE__ to __dir__

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ db_namespace = namespace :db do
 
   desc 'migrate the database (options: VERSION=x).'
   task :migrate do
-    ActiveRecord::Migrator.migrations_paths = [File.join(__FILE__, 'db/migrate')]
+    ActiveRecord::Migrator.migrations_paths = [File.join(__dir__, 'db/migrate')]
     ActiveRecord::Migration.verbose = true
     version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
     args = [ActiveRecord::Migrator.migrations_paths, ActiveRecord::SchemaMigration]


### PR DESCRIPTION
Fixes:
https://github.com/lewagon/teachers/issues/281

`__FILE__` returns `"(pry)"` within the task
`__dir__` returns `"."` which fixes the wrongly built folder path for the migrations.
